### PR TITLE
Update navigation menu to have only the first section of each teams

### DIFF
--- a/audit-report/index.html
+++ b/audit-report/index.html
@@ -98,7 +98,7 @@
                 // element will be used.
                 // Note: that a section data-menu-title attribute or an element
                 // with a menu-title class will take precedence over this option
-                titleSelector: 'h1, h2, h3, h4, h5, h6',
+                titleSelector: 'h1, h2, h3',
 
                 // If slides do not have a matching title, attempt to use the
                 // start of the text content as the title instead
@@ -106,7 +106,7 @@
 
                 // Hide slides from the menu that do not have a title.
                 // Set to 'true' to only list slides with titles.
-                hideMissingTitles: false,
+                hideMissingTitles: true,
 
                 // Adds markers to the slide titles to indicate the
                 // progress through the presentation. Set to 'false'

--- a/report-imageScan.md.tmpl
+++ b/report-imageScan.md.tmpl
@@ -79,7 +79,7 @@ Using only internal registry allow you to:
 {{- if mods $index 0 30 }}
 
 
-### Vulnerabilities - {{ $area.AreaName }} - {{ $team.TeamName }} - part {{ $partNumber }} 
+###{{- if gt $partNumber 1 -}}#{{- end }} Vulnerabilities - {{ $area.AreaName }} - {{ $team.TeamName }} {{- if gt $partNumber 1 -}} - part {{ $partNumber }} {{- end }} 
 {{ safe "<!-- .element: class=\"title-detailed-page\" -->" }}
 
 | Image | CVE | Severity | PkgName | Description |

--- a/report.md.tmpl
+++ b/report.md.tmpl
@@ -85,7 +85,7 @@ Using only internal registry allow you to:
 {{- if mods $index 0 30 }}
 
 
-### Vulnerabilities - {{ $area.AreaName }} - {{ $team.TeamName }} - part {{ $partNumber }} 
+###{{- if gt $partNumber 1 -}}#{{- end }} Vulnerabilities - {{ $area.AreaName }} - {{ $team.TeamName }} {{- if gt $partNumber 1 -}} - part {{ $partNumber }} {{- end }} 
 {{ safe "<!-- .element: class=\"title-detailed-page\" -->" }}
 
 | Image | CVE | Severity | PkgName | Description |


### PR DESCRIPTION
The first page of each team will be referenced in the menu because the markdown will have a h3 tag `###` and the others pages will have a h4 `####`. 